### PR TITLE
Bypass auth if no credentials are set

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -13,6 +13,9 @@ export class AccessToken {
   }
 
   async get() {
+    if (!useAuthStore().clientId && !useAuthStore().clientSecret) {
+      return;
+    }
     if (!this.token || !this.tokenExpiration || this.tokenExpiration <= Date.now()) {
       await this.refresh()
     }
@@ -51,10 +54,12 @@ export const AuthMiddleware: Middleware = {
 
     const accessToken = await useAuthStore().accessToken.get();
 
-    request.headers.set(
-        'Authorization',
-        accessToken
-    )
+    if (accessToken) {
+      request.headers.set(
+          'Authorization',
+          accessToken
+      )
+    }
 
     return request
   },


### PR DESCRIPTION
Thank you for this demo app. I was playing with it a bit, but the server-side component I have here doesn't have authentication, so the auth refresh was getting in the way.

Perhaps it would make sense to skip the authentication altogether if the user didn't set it? If you agree, here's this PR.